### PR TITLE
Added support for full domain urls for cached images

### DIFF
--- a/config/ht-img-module.global.php
+++ b/config/ht-img-module.global.php
@@ -68,6 +68,13 @@ $options = [
       * Default: htimg
       */
     //'cache_path' => 'htimg'
+    
+    /**
+      * Cache Url(for external urls like static.example.com)
+      *
+      * Default: ''
+      */
+    //'cache_url' => ''
 
     /**
      * Filter Loaders

--- a/src/Options/CacheOptionsInterface.php
+++ b/src/Options/CacheOptionsInterface.php
@@ -8,6 +8,8 @@ interface CacheOptionsInterface
     public function getWebRoot();
 
     public function getCachePath();
+    
+    public function getCacheUrl();
 
     public function getCacheExpiry();
 

--- a/src/Options/ModuleOptions.php
+++ b/src/Options/ModuleOptions.php
@@ -31,6 +31,8 @@ class ModuleOptions extends AbstractOptions implements CacheOptionsInterface, Fi
     protected $filterLoaders = [];
 
     protected $cachePath = 'htimg';
+    
+    protected $cacheUrl = '';
 
     protected $cacheExpiry = 86400;
 
@@ -138,6 +140,18 @@ class ModuleOptions extends AbstractOptions implements CacheOptionsInterface, Fi
         return $this->filterLoaders;
     }
 
+    public function setCacheUrl($cacheUrl)
+    {
+        $this->cacheUrl = $cacheUrl;
+
+        return $this;
+    }
+
+    public function getCacheUrl()
+    {
+        return $this->cacheUrl;
+    }
+    
     public function setCachePath($cachePath)
     {
         $this->cachePath = $cachePath;

--- a/src/Service/CacheManager.php
+++ b/src/Service/CacheManager.php
@@ -40,18 +40,26 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function getCacheUrl($relativeName, $filter, $formatOrImage = null)
+    public function getCacheUrl($relativeName, $filter, $formatOrImage = null, $useFullUrl = false)
     {
         if (is_readable($formatOrImage)) {
             $format = pathinfo($formatOrImage, PATHINFO_EXTENSION);
-        } else {
+        } 
+        else {
             $format = $formatOrImage;
         }
+        
+        if ($useFullUrl && $this->useCacheUrl()) {
+            return $this->cacheOptions->getCacheUrl() . '/' . $filter . '/'. $relativeName . '.' . $format;
+        }
+        
         if (!$format) {
              return $this->cacheOptions->getCachePath() . '/' . $filter . '/'. $relativeName;
-        } else {
+        } 
+        else {
             return $this->getCacheUrl($relativeName, $filter) . '.' . $format;
         }
+    
     }
 
     /**
@@ -65,13 +73,13 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function createCache($relativeName, $filter, ImageInterface $image, $formatOrImage = null)
+    public function createCache($relativeName, $filter, ImageInterface $image, $formatOrImage = null, array $saveOptions = [])
     {
         $cachePath = $this->getCachePath($relativeName, $filter, $formatOrImage);
         if (!is_dir(dirname($cachePath))) {
             mkdir(dirname($cachePath), 0755, true);
         }
-        $image->save($cachePath);
+        $image->save($cachePath, $saveOptions);
     }
 
     /**
@@ -103,9 +111,8 @@ class CacheManager implements CacheManagerInterface
     public function useCacheUrl()
     {
         if($this->cacheOptions->getCacheUrl()) {
-            $this->cacheOptions->setCachePath('');
-            return $this->cacheOptions->getCacheUrl();
+            return true;
         }
-        return null;
+        return false;
     }
 }

--- a/src/Service/CacheManager.php
+++ b/src/Service/CacheManager.php
@@ -65,13 +65,13 @@ class CacheManager implements CacheManagerInterface
     /**
      * {@inheritDoc}
      */
-    public function createCache($relativeName, $filter, ImageInterface $image, $formatOrImage = null, array $saveOptions = [])
+    public function createCache($relativeName, $filter, ImageInterface $image, $formatOrImage = null)
     {
         $cachePath = $this->getCachePath($relativeName, $filter, $formatOrImage);
         if (!is_dir(dirname($cachePath))) {
             mkdir(dirname($cachePath), 0755, true);
         }
-        $image->save($cachePath, $saveOptions);
+        $image->save($cachePath);
     }
 
     /**
@@ -95,5 +95,17 @@ class CacheManager implements CacheManagerInterface
         }
 
         return $this->cacheOptions->getEnableCache();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public function useCacheUrl()
+    {
+        if($this->cacheOptions->getCacheUrl()) {
+            $this->cacheOptions->setCachePath('');
+            return $this->cacheOptions->getCacheUrl();
+        }
+        return null;
     }
 }

--- a/src/Service/CacheManager.php
+++ b/src/Service/CacheManager.php
@@ -110,9 +110,6 @@ class CacheManager implements CacheManagerInterface
      */
     public function useCacheUrl()
     {
-        if($this->cacheOptions->getCacheUrl()) {
-            return true;
-        }
-        return false;
+        return $this->cacheOptions->getCacheUrl() ? true: false;
     }
 }

--- a/src/Service/CacheManagerInterface.php
+++ b/src/Service/CacheManagerInterface.php
@@ -21,9 +21,10 @@ interface CacheManagerInterface
      * @param  string      $relativeName
      * @param  string      $filter
      * @param  string|null $formatOrImage
+     * @param  bool|false  $useFullUrl
      * @return string
      */
-    public function getCacheUrl($relativeName, $filter, $formatOrImage = null);
+    public function getCacheUrl($relativeName, $filter, $formatOrImage = null, $useFullUrl = false);
 
     /**
      * Gets filesystem path for a cache
@@ -65,4 +66,11 @@ interface CacheManagerInterface
      * @return bool
      */
     public function isCachingEnabled($filter, array $filterOptions);
+
+    /**
+     * Check if we use full url for caching
+     * 
+     * @return bool
+     */
+    public function useCacheUrl();
 }

--- a/src/View/Helper/ImgUrl.php
+++ b/src/View/Helper/ImgUrl.php
@@ -5,6 +5,7 @@ namespace HtImgModule\View\Helper;
 use Zend\View\Helper\AbstractHelper;
 use HtImgModule\Service\CacheManagerInterface;
 use HtImgModule\Imagine\Filter\FilterManagerInterface;
+use HtImgModule\Exception;
 use HtImgModule\Imagine\Loader\LoaderManagerInterface;
 
 class ImgUrl extends AbstractHelper
@@ -59,8 +60,12 @@ class ImgUrl extends AbstractHelper
             $format = $binary->getFormat() ?: 'png';
         }
         if ($this->cacheManager->isCachingEnabled($filter, $filterOptions) && $this->cacheManager->cacheExists($relativeName, $filter, $format)) {
+    
+            if($this->cacheManager->useCacheUrl()) {
+                return $this->cacheManager->useCacheUrl() . $this->cacheManager->getCacheUrl($relativeName, $filter, $format);
+            }
+            
             $basePathHelper = $this->getView()->plugin('basePath');
-
             return $basePathHelper() . '/'. $this->cacheManager->getCacheUrl($relativeName, $filter, $format);
         }
 

--- a/src/View/Helper/ImgUrl.php
+++ b/src/View/Helper/ImgUrl.php
@@ -59,10 +59,11 @@ class ImgUrl extends AbstractHelper
             $binary = $this->loaderManager->loadBinary($relativeName, $filter);
             $format = $binary->getFormat() ?: 'png';
         }
+        
         if ($this->cacheManager->isCachingEnabled($filter, $filterOptions) && $this->cacheManager->cacheExists($relativeName, $filter, $format)) {
     
             if($this->cacheManager->useCacheUrl()) {
-                return $this->cacheManager->useCacheUrl() . $this->cacheManager->getCacheUrl($relativeName, $filter, $format);
+                return $this->cacheManager->getCacheUrl($relativeName, $filter, $format, true);
             }
             
             $basePathHelper = $this->getView()->plugin('basePath');

--- a/tests/HtImgModuleTest/View/Helper/ImgUrlTest.php
+++ b/tests/HtImgModuleTest/View/Helper/ImgUrlTest.php
@@ -98,7 +98,7 @@ class ImgUrlTest extends \PHPUnit_Framework_TestCase
         $cacheManager->expects($this->once())
             ->method('getCacheUrl')
             ->with('path/to/some/random/image/', 'foo_view_filter', 'jpeg', true)
-            ->will($this->returnValue('http:://static.example.com/foo_view_filter/path/to/some/random/image/flowers.jpg'));
+            ->will($this->returnValue('http://static.example.com/foo_view_filter/path/to/some/random/image/flowers.jpg'));
         $loaderManager = $this->getMock('HtImgModule\Imagine\Loader\LoaderManagerInterface');
         $filterManager = $this->getMock('HtImgModule\Imagine\Filter\FilterManagerInterface');
         $filterOptions = ['format' => 'jpeg'];
@@ -117,6 +117,6 @@ class ImgUrlTest extends \PHPUnit_Framework_TestCase
         );
         $renderer = $this->getMock('Zend\View\Renderer\PhpRenderer');
         $helper->setView($renderer);
-        $this->assertEquals('http:://static.example.com/foo_view_filter/path/to/some/random/image/flowers.jpg', $helper('path/to/some/random/image/', 'foo_view_filter'));
+        $this->assertEquals('http://static.example.com/foo_view_filter/path/to/some/random/image/flowers.jpg', $helper('path/to/some/random/image/', 'foo_view_filter'));
     }
 }


### PR DESCRIPTION
I needed to add support for cookieless domain, static files domain. Now you have new attribute in config cache_url where you can add external url like http://static.example.com. If this is set then  that url is used. I think i am not the only one who needs it.
