### PR TITLE
ZF3 compatibility (No BC break)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,57 @@
 language: php
 
-php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
-  - hhvm  
+cache:
+  directories:
+    - $HOME/.composer/cache
+    - vendor
 
-before_script:
- - composer install
- - wget https://scrutinizer-ci.com/ocular.phar
+env:
+  global:
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+
+matrix:
+  fast_finish: true
+  include:
+    - php: 5.6
+      env:
+        - DEPS=lowest
+    - php: 5.6
+      env:
+        - DEPS=latest
+    - php: 7.0
+      env:
+        - DEPS=lowest
+    - php: 7.0
+      env:
+        - DEPS=latest
+    - php: 7.1
+      env:
+        - DEPS=lowest
+    - php: 7.1
+      env:
+        - DEPS=latest
+    - php: hhvm
+      env:
+        - DEPS=lowest
+    - php: hhvm
+      env:
+        - DEPS=latest
+  allow_failures:
+    - php: hhvm
+    - php: 7.1
+
+before_install:
+  - travis_retry composer self-update
+
+install:
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
+  - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
+  - travis_retry composer install $COMPOSER_ARGS
+  - composer show
+  - wget https://scrutinizer-ci.com/ocular.phar
 
 script:
   - (cd tests ; ../vendor/bin/phpunit ./)
 
 after_script:
   - php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml
-  
-matrix:
-  allow_failures:
-    - php: hhvm 

--- a/Module.php
+++ b/Module.php
@@ -1,10 +1,14 @@
 <?php
 namespace HtImgModule;
 
+use HtImgModule\View\Helper\DisplayImage;
+use HtImgModule\View\Helper\Factory\ImgUrlFactory;
+use HtImgModule\View\Helper\ImgUrl;
 use Zend\ModuleManager\Feature\AutoloaderProviderInterface;
 use Zend\ModuleManager\Feature\ConfigProviderInterface;
 use Zend\ModuleManager\Feature\ServiceProviderInterface;
 use Zend\ModuleManager\Feature\ViewHelperProviderInterface;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 class Module implements
     AutoloaderProviderInterface,
@@ -64,14 +68,12 @@ class Module implements
     {
         return [
             'factories' => [
-                'HtImgModule\View\Helper\ImgUrl' => 'HtImgModule\View\Helper\Factory\ImgUrlFactory',
-            ],
-            'invokables' => [
-                'HtImgModule\View\Helper\DisplayImage' => 'HtImgModule\View\Helper\DisplayImage',
+                ImgUrl::class => ImgUrlFactory::class,
+                DisplayImage::class => InvokableFactory::class,
             ],
             'aliases' => [
-                'htDisplayImage' => 'HtImgModule\View\Helper\DisplayImage',
-                'htImgUrl' => 'HtImgModule\View\Helper\ImgUrl',
+                'htDisplayImage' => DisplayImage::class,
+                'htImgUrl' => ImgUrl::class,
             ]
         ];
     }

--- a/composer.json
+++ b/composer.json
@@ -4,6 +4,7 @@
     "type": "library",
     "keywords": [
         "zf2",
+        "zf3",
         "module",
         "zendframework"
     ],
@@ -16,30 +17,38 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
-        "zendframework/zend-mvc": "~2.2",
-        "zendframework/zend-servicemanager": "~2.2",
-        "zendframework/zend-modulemanager": "~2.2",
-        "zendframework/zend-stdlib": "~2.2",
-        "zendframework/zend-http": "~2.2",
-        "zendframework/zend-eventmanager": "~2.2",
+        "php": "^5.6 || ^7.0",
+        "zendframework/zend-mvc": "^2.7.10 || ^3.0",
+        "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
+        "zendframework/zend-modulemanager": "^2.6",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0",
+        "zendframework/zend-hydrator": "^1.1 || ^2.2",
+        "zendframework/zend-http": "^2.5",
+        "zendframework/zend-eventmanager": "^2.7 || ^3.0",
         "imagine/Imagine": "0.6.*",
         "symfony/http-foundation": "~2.3"
     },
     "require-dev": {
         "ext-gd": "*",
-        "zendframework/zend-escaper": "~2.2",
-        "zendframework/zend-view": "~2.2",
-        "zendframework/zend-filter": "~2.2",
+        "zendframework/zend-escaper": "^2.2",
+        "zendframework/zend-view": "^2.7",
+        "zendframework/zend-filter": "^2.5",
         "league/flysystem": "0.4.*",
-        "knplabs/gaufrette":"0.1.*",
-        "phpunit/phpunit": "4.1.*",
+        "knplabs/gaufrette":"^0.1.9",
+        "phpunit/phpunit": "^4.1",
         "phine/test": "1.*"
     },
     "suggest": {
         "league/flysystem": "To use this library to load image",
         "knplabs/gaufrette": "To use this library to load image",
         "zendframework/zend-view": "To use some view helpers provided this module"
+    },
+    "extra": {
+        "zf": {
+            "module": [
+                "HtImgModule"
+            ]
+        }
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
         "zendframework/zend-servicemanager": "^2.7.6 || ^3.1",
         "zendframework/zend-modulemanager": "^2.6",
         "zendframework/zend-stdlib": "^2.7 || ^3.0",
-        "zendframework/zend-hydrator": "^1.1 || ^2.2",
         "zendframework/zend-http": "^2.5",
         "zendframework/zend-eventmanager": "^2.7 || ^3.0",
         "imagine/Imagine": "0.6.*",

--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,4 +1,8 @@
 <?php
+
+namespace HtImgModule;
+use HtImgModule\View\Strategy\ImageStrategy;
+
 return [
     'htimg' => [
         'filters' => [ // Just one for quick and easy way
@@ -41,13 +45,16 @@ return [
         ]
     ],
     'controllers' => [
+        'aliases' => [
+            'htimg' => Controller\ImageController::class,
+        ],
         'factories' => [
-            'htimg' => 'HtImgModule\Controller\Factory\ImageControllerFactory'
+            Controller\ImageController::class => Controller\Factory\ImageControllerFactory::class
         ]
     ],
     'view_manager' => [
         'strategies' => [
-            'HtImgModule\View\Strategy\ImageStrategy',
+            ImageStrategy::class,
         ],
     ],
 ];

--- a/src/Controller/Factory/ImageControllerFactory.php
+++ b/src/Controller/Factory/ImageControllerFactory.php
@@ -1,20 +1,45 @@
 <?php
 namespace HtImgModule\Controller\Factory;
 
+use HtImgModule\Service\ImageService;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Controller\ImageController;
 
 class ImageControllerFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $controllers)
+
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return ImageController
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        /** @var ServiceLocatorInterface $serviceLocator */
-        $serviceLocator = $controllers->getServiceLocator();
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator();
+        }
 
         /** @var \HtImgModule\Service\ImageService $imageService */
-        $imageService = $serviceLocator->get('HtImgModule\Service\ImageService');
+        $imageService = $container->get(ImageService::class);
 
         return new ImageController($imageService);
+    }
+
+    public function createService(ServiceLocatorInterface $controllers)
+    {
+        return $this($controllers, ImageController::class);
     }
 }

--- a/src/Controller/Factory/ImageControllerFactory.php
+++ b/src/Controller/Factory/ImageControllerFactory.php
@@ -28,7 +28,7 @@ class ImageControllerFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (! method_exists($container, 'configure')) {
+        if (!method_exists($container, 'configure')) {
             $container = $container->getServiceLocator();
         }
 

--- a/src/Factory/CacheManagerFactory.php
+++ b/src/Factory/CacheManagerFactory.php
@@ -1,17 +1,39 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Service\CacheManager;
 
 class CacheManagerFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         /** @var \HtImgModule\Options\CacheOptionsInterface $options */
-        $options = $serviceLocator->get('HtImg\ModuleOptions');
+        $options = $container->get('HtImg\ModuleOptions');
 
         return new CacheManager($options);
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, CacheManager::class);
     }
 }

--- a/src/Factory/FilterLoaderPluginManagerFactory.php
+++ b/src/Factory/FilterLoaderPluginManagerFactory.php
@@ -1,6 +1,10 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager;
@@ -8,12 +12,27 @@ use Zend\ServiceManager\Config;
 
 class FilterLoaderPluginManagerFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $options       = $container->get('HtImg\ModuleOptions');
+        return new FilterLoaderPluginManager($container, $options->getFilterLoaders());
+    }
+
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        $options       = $serviceLocator->get('HtImg\ModuleOptions');
-        $pluginManager = new FilterLoaderPluginManager(new Config($options->getFilterLoaders()));
-        $pluginManager->setServiceLocator($serviceLocator);
-
-        return $pluginManager;
+        return $this($serviceLocator, FilterLoaderPluginManager::class);
     }
 }

--- a/src/Factory/FilterManagerFactory.php
+++ b/src/Factory/FilterManagerFactory.php
@@ -1,20 +1,43 @@
 <?php
 namespace HtImgModule\Factory;
 
+use HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Filter\FilterManager;
 
 class FilterManagerFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         /** @var \HtImgModule\Options\FilterOptionsInterface $options */
-        $options                    = $serviceLocator->get('HtImg\ModuleOptions');
+        $options                    = $container->get('HtImg\ModuleOptions');
 
         /** @var ServiceLocatorInterface $filterLoaderPluginManager */
-        $filterLoaderPluginManager  = $serviceLocator->get('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager');
+        $filterLoaderPluginManager  = $container->get(FilterLoaderPluginManager::class);
 
         return new FilterManager($options, $filterLoaderPluginManager);
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, FilterManager::class);
     }
 }

--- a/src/Factory/ImageServiceFactory.php
+++ b/src/Factory/ImageServiceFactory.php
@@ -2,28 +2,48 @@
 
 namespace HtImgModule\Factory;
 
+use HtImgModule\Imagine\Filter\FilterManager;
+use HtImgModule\Imagine\Loader\LoaderManager;
+use HtImgModule\Service\CacheManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Service\ImageService;
 
 class ImageServiceFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         /** @var \Imagine\Image\ImagineInterface $imagine */
-        $imagine            = $serviceLocator->get('HtImg\Imagine');
-
+        $imagine            = $container->get('HtImg\Imagine');
         /** @var \HtImgModule\Service\CacheManagerInterface $cacheManager */
-        $cacheManager       = $serviceLocator->get('HtImgModule\Service\CacheManager');
-
+        $cacheManager       = $container->get(CacheManager::class);
         /** @var \HtImgModule\Imagine\Loader\LoaderManagerInterface $imageLoaderManager */
-        $imageLoaderManager = $serviceLocator->get('HtImgModule\Imagine\Loader\LoaderManager');
-
+        $imageLoaderManager = $container->get(LoaderManager::class);
         /** @var \HtImgModule\Imagine\Filter\FilterManagerInterface $filterManager */
-        $filterManager      = $serviceLocator->get('HtImgModule\Imagine\Filter\FilterManager');
+        $filterManager      = $container->get(FilterManager::class);
 
-        $imageService       = new ImageService($cacheManager, $imagine, $filterManager, $imageLoaderManager);
+        return new ImageService($cacheManager, $imagine, $filterManager, $imageLoaderManager);
+    }
 
-        return $imageService;
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ImageService::class);
     }
 }

--- a/src/Factory/ImageStrategyFactory.php
+++ b/src/Factory/ImageStrategyFactory.php
@@ -2,17 +2,39 @@
 
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\View\Strategy\ImageStrategy;
 
 class ImageStrategyFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return ImageStrategy
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
         /** @var \Imagine\Image\ImagineInterface $imagine */
-        $imagine = $serviceLocator->get('HtImg\Imagine');
+        $imagine = $container->get('HtImg\Imagine');
 
         return new ImageStrategy($imagine);
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ImageStrategy::class);
     }
 }

--- a/src/Factory/Imagine/Loader/FileSystemLoaderFactory.php
+++ b/src/Factory/Imagine/Loader/FileSystemLoaderFactory.php
@@ -1,16 +1,41 @@
 <?php
 namespace HtImgModule\Factory\Imagine\Loader;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Loader\FileSystemLoader;
 
 class FileSystemLoaderFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        return new FileSystemLoader($container->get('HtImg\RelativePathResolver'));
+    }
+
     public function createService(ServiceLocatorInterface $loaders)
     {
-        $resolver = $loaders->getServiceLocator()->get('HtImg\RelativePathResolver');
-
-        return new FileSystemLoader($resolver);
+        return $this($loaders, FileSystemLoader::class);
     }
 }

--- a/src/Factory/Imagine/Loader/LoaderManagerFactory.php
+++ b/src/Factory/Imagine/Loader/LoaderManagerFactory.php
@@ -1,19 +1,44 @@
 <?php
 namespace HtImgModule\Factory\Imagine\Loader;
 
+use HtImgModule\Binary\MimeTypeGuesser;
+use HtImgModule\Imagine\Filter\FilterManager;
+use HtImgModule\Imagine\Loader\LoaderPluginManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Loader\LoaderManager;
 
 class LoaderManagerFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $filterManager      = $serviceLocator->get('HtImgModule\Imagine\Filter\FilterManager');
-        $imageLoaders       = $serviceLocator->get('HtImgModule\Imagine\Loader\LoaderPluginManager');
-        $defaultImageLoader = $serviceLocator->get('HtImg\ModuleOptions')->getDefaultImageLoader();
-        $mimeTypeGuesser    = $serviceLocator->get('HtImgModule\Binary\MimeTypeGuesser');
+        $filterManager      = $container->get(FilterManager::class);
+        $imageLoaders       = $container->get(LoaderPluginManager::class);
+        $defaultImageLoader = $container->get('HtImg\ModuleOptions')->getDefaultImageLoader();
+        $mimeTypeGuesser    = $container->get(MimeTypeGuesser::class);
 
         return new LoaderManager($imageLoaders, $filterManager, $defaultImageLoader, $mimeTypeGuesser);
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, LoaderManager::class);
     }
 }

--- a/src/Factory/Imagine/Loader/LoaderPluginManagerFactory.php
+++ b/src/Factory/Imagine/Loader/LoaderPluginManagerFactory.php
@@ -1,6 +1,10 @@
 <?php
 namespace HtImgModule\Factory\Imagine\Loader;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\Config;
@@ -8,8 +12,26 @@ use HtImgModule\Imagine\Loader\LoaderPluginManager;
 
 class LoaderPluginManagerFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new LoaderPluginManager($container, $container->get('Config')['htimg']['loaders']);
+    }
+
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new LoaderPluginManager(new Config($serviceLocator->get('Config')['htimg']['loaders']));
+        return $this($serviceLocator, LoaderPluginManager::class);
     }
 }

--- a/src/Factory/Imagine/Loader/SimpleFileSystemLoaderFactory.php
+++ b/src/Factory/Imagine/Loader/SimpleFileSystemLoaderFactory.php
@@ -1,13 +1,16 @@
 <?php
 namespace HtImgModule\Factory\Imagine\Loader;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Loader\SimpleFileSystemLoader;
-use Zend\ServiceManager\MutableCreationOptionsInterface;
 use HtImgModule\Exception;
 
-class SimpleFileSystemLoaderFactory implements FactoryInterface, MutableCreationOptionsInterface
+class SimpleFileSystemLoaderFactory implements FactoryInterface
 {
     /**
      * @var array
@@ -22,12 +25,30 @@ class SimpleFileSystemLoaderFactory implements FactoryInterface, MutableCreation
         $this->options = $options;
     }
 
-    public function createService(ServiceLocatorInterface $loaders)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (!isset($this->options['root_path'])) {
+        if (!isset($options['root_path'])) {
             throw new Exception\InvalidArgumentException('Missing "root_path" in options array');
         }
 
-        return new SimpleFileSystemLoader($this->options['root_path']);
+        return new SimpleFileSystemLoader($options['root_path']);
+    }
+
+    public function createService(ServiceLocatorInterface $loaders)
+    {
+        return $this($loaders, SimpleFileSystemLoader::class, $this->options);
     }
 }

--- a/src/Factory/ImagineFactory.php
+++ b/src/Factory/ImagineFactory.php
@@ -1,6 +1,10 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
@@ -12,11 +16,29 @@ class ImagineFactory implements FactoryInterface
         'gmagick' => 'Imagine\Gmagick\Imagine'
     ];
 
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $options = $serviceLocator->get('HtImg\ModuleOptions');
+        $options = $container->get('HtImg\ModuleOptions');
         $class   = $this->classes[$options->getDriver()];
 
         return new $class();
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, null);
     }
 }

--- a/src/Factory/MimeTypeGuesserFactory.php
+++ b/src/Factory/MimeTypeGuesserFactory.php
@@ -1,6 +1,10 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Symfony\Component\HttpFoundation\File\MimeType\MimeTypeGuesser as SymfonyMimeTypeGuesser;
@@ -8,10 +12,28 @@ use HtImgModule\Binary\MimeTypeGuesser;
 
 class MimeTypeGuesserFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return MimeTypeGuesser
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $symfonyMimeTypeGuesser = SymfonyMimeTypeGuesser ::getInstance();
+        $symfonyMimeTypeGuesser = SymfonyMimeTypeGuesser::getInstance();
 
         return new MimeTypeGuesser($symfonyMimeTypeGuesser);
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, MimeTypeGuesser::class);
     }
 }

--- a/src/Factory/ModuleOptionsFactory.php
+++ b/src/Factory/ModuleOptionsFactory.php
@@ -1,14 +1,36 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Options\ModuleOptions;
 
 class ModuleOptionsFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return ModuleOptions
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        return new ModuleOptions($container->get('Config')['htimg']);
+    }
+
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new ModuleOptions($serviceLocator->get('Config')['htimg']);
+        return $this($serviceLocator, ModuleOptions::class);
     }
 }

--- a/src/Factory/RelativePathResolverFactory.php
+++ b/src/Factory/RelativePathResolverFactory.php
@@ -2,20 +2,43 @@
 namespace HtImgModule\Factory;
 
 use HtImgModule\Imagine\Resolver\AggregateResolver;
+use HtImgModule\Imagine\Resolver\ResolverManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 class RelativePathResolverFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return AggregateResolver
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $options         = $serviceLocator->get('HtImg\ModuleOptions');
+        $options         = $container->get('HtImg\ModuleOptions');
         $resolver        = new AggregateResolver();
-        $resolverManager = $serviceLocator->get('HtImgModule\Imagine\Resolver\ResolverManager');
+        $resolverManager = $container->get(ResolverManager::class);
         foreach ($options->getImageResolvers() as $priority => $subResolverName) {
             $resolver->attach($resolverManager->get($subResolverName), $priority);
         }
 
         return $resolver;
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, AggregateResolver::class);
     }
 }

--- a/src/Factory/ResolverManagerFactory.php
+++ b/src/Factory/ResolverManagerFactory.php
@@ -1,6 +1,10 @@
 <?php
 namespace HtImgModule\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Resolver\ResolverManager;
@@ -8,12 +12,29 @@ use Zend\ServiceManager\Config;
 
 class ResolverManagerFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $serviceLocator)
+
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return ResolverManager
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $config          = new Config($serviceLocator->get('Config')['htimg']['resolvers_manager']);
-        $resolverManager = new ResolverManager($config);
-        $resolverManager->setServiceLocator($serviceLocator);
+        $resolverManager = new ResolverManager($container, $container->get('Config')['htimg']['resolvers_manager']);
 
         return $resolverManager;
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator)
+    {
+        return $this($serviceLocator, ResolverManager::class);
     }
 }

--- a/src/Imagine/Filter/Loader/Factory/BackgroundFactory.php
+++ b/src/Imagine/Filter/Loader/Factory/BackgroundFactory.php
@@ -1,18 +1,43 @@
 <?php
 namespace HtImgModule\Imagine\Filter\Loader\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
 use HtImgModule\Imagine\Filter\Loader\Background;
 
 class BackgroundFactory implements FactoryInterface
 {
-     public function createService(ServiceLocatorInterface $filterLoaders)
-     {
-         $serviceLocator = $filterLoaders->getServiceLocator();
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
 
-         return new Background(
-            $serviceLocator->get('HtImg\Imagine')
-         );
-     }
+        return new Background(
+            $container->get('HtImg\Imagine')
+        );
+    }
+
+    public function createService(ServiceLocatorInterface $filterLoaders)
+    {
+        return $this($filterLoaders, Background::class);
+    }
 }

--- a/src/Imagine/Filter/Loader/Factory/ChainFactory.php
+++ b/src/Imagine/Filter/Loader/Factory/ChainFactory.php
@@ -2,16 +2,42 @@
 
 namespace HtImgModule\Imagine\Filter\Loader\Factory;
 
+use HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
 use HtImgModule\Imagine\Filter\Loader\Chain;
 
 class ChainFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return Chain
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        return new Chain($container->get(FilterLoaderPluginManager::class));
+    }
+
     public function createService(ServiceLocatorInterface $filterLoaders)
     {
-        $serviceLocator = $filterLoaders->getServiceLocator();
-
-        return new Chain($serviceLocator->get('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager'));
+        return $this($filterLoaders, Chain::class);
     }
 }

--- a/src/Imagine/Filter/Loader/Factory/PasteFactory.php
+++ b/src/Imagine/Filter/Loader/Factory/PasteFactory.php
@@ -1,19 +1,44 @@
 <?php
 namespace HtImgModule\Imagine\Filter\Loader\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
 use HtImgModule\Imagine\Filter\Loader\Paste;
 
 class PasteFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        return new Paste(
+            $container->get('HtImg\Imagine'),
+            $container->get('HtImg\RelativePathResolver')
+        );
+    }
+
      public function createService(ServiceLocatorInterface $filterLoaders)
      {
-         $serviceLocator = $filterLoaders->getServiceLocator();
-
-         return new Paste(
-            $serviceLocator->get('HtImg\Imagine'),
-            $serviceLocator->get('HtImg\RelativePathResolver')
-         );
+        return $this($filterLoaders, Paste::class);
      }
 }

--- a/src/Imagine/Filter/Loader/Factory/WatermarkFactory.php
+++ b/src/Imagine/Filter/Loader/Factory/WatermarkFactory.php
@@ -1,19 +1,44 @@
 <?php
 namespace HtImgModule\Imagine\Filter\Loader\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
 use HtImgModule\Imagine\Filter\Loader\Watermark;
 
 class WatermarkFactory implements FactoryInterface
 {
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+
+        return new Watermark(
+            $container->get('HtImg\Imagine'),
+            $container->get('HtImg\RelativePathResolver')
+        );
+    }
+
      public function createService(ServiceLocatorInterface $filterLoaders)
      {
-         $serviceLocator = $filterLoaders->getServiceLocator();
-
-         return new Watermark(
-            $serviceLocator->get('HtImg\Imagine'),
-            $serviceLocator->get('HtImg\RelativePathResolver')
-         );
+        return $this($filterLoaders, Watermark::class);
      }
 }

--- a/src/Imagine/Filter/Loader/FilterLoaderPluginManager.php
+++ b/src/Imagine/Filter/Loader/FilterLoaderPluginManager.php
@@ -3,14 +3,18 @@ namespace HtImgModule\Imagine\Filter\Loader;
 
 use Zend\ServiceManager\AbstractPluginManager;
 use HtImgModule\Exception;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 class FilterLoaderPluginManager extends AbstractPluginManager
 {
-    protected $invokableClasses  = [
-        'crop' => 'HtImgModule\Imagine\Filter\Loader\Crop',
-        'relativeresize' => 'HtImgModule\Imagine\Filter\Loader\RelativeResize',
-        'resize' => 'HtImgModule\Imagine\Filter\Loader\Resize',
-        'thumbnail' => 'HtImgModule\Imagine\Filter\Loader\Thumbnail',
+    protected $instanceOf = LoaderInterface::class;
+
+    protected $aliases  = [
+        'crop' => Crop::class,
+        'relativeresize' => RelativeResize::class,
+        'resize' => Resize::class,
+        'thumbnail' => Thumbnail::class,
     ];
 
     protected $factories = [
@@ -18,17 +22,29 @@ class FilterLoaderPluginManager extends AbstractPluginManager
         'paste' => 'HtImgModule\Imagine\Filter\Loader\Factory\PasteFactory',
         'watermark' => 'HtImgModule\Imagine\Filter\Loader\Factory\WatermarkFactory',
         'background' => 'HtImgModule\Imagine\Filter\Loader\Factory\BackgroundFactory',
+        Crop::class => InvokableFactory::class,
+        RelativeResize::class => InvokableFactory::class,
+        Resize::class => InvokableFactory::class,
+        Thumbnail::class => InvokableFactory::class,
     ];
 
-    public function validatePlugin($plugin)
+    public function validate($instance)
     {
-        if ($plugin instanceof LoaderInterface) {
-            return; // we're okay
+        if (!$instance instanceof $this->instanceOf) {
+            throw new InvalidServiceException(sprintf(
+                'Invalid plugin "%s" created; not an instance of %s',
+                get_class($instance),
+                $this->instanceOf
+            ));
         }
+    }
 
-        throw new Exception\InvalidArgumentException(sprintf(
-            'Plugin of type %s is invalid; must implement HtImgModule\Imagine\Filter\Loader\LoaderInterface',
-            (is_object($plugin) ? get_class($plugin) : gettype($plugin))
-        ));
+    public function validatePlugin($instance)
+    {
+        try {
+            $this->validate($instance);
+        } catch (InvalidServiceException $e) {
+            throw new Exception\InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/src/Imagine/Resolver/Factory/ImageMapResolverFactory.php
+++ b/src/Imagine/Resolver/Factory/ImageMapResolverFactory.php
@@ -1,17 +1,42 @@
 <?php
 namespace HtImgModule\Imagine\Resolver\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Resolver\ImageMapResolver;
 
 class ImageMapResolverFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $resolvers)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $serviceLocator = $resolvers->getServiceLocator();
-        $options = $serviceLocator->get('HtImg\ModuleOptions');
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+        $options = $container->get('HtImg\ModuleOptions');
 
         return new ImageMapResolver($options->getImgSourceMap());
+    }
+
+    public function createService(ServiceLocatorInterface $resolvers)
+    {
+        return $this($resolvers, ImageMapResolver::class);
     }
 }

--- a/src/Imagine/Resolver/Factory/ImagePathStackResolverFactory.php
+++ b/src/Imagine/Resolver/Factory/ImagePathStackResolverFactory.php
@@ -1,19 +1,44 @@
 <?php
 namespace HtImgModule\Imagine\Resolver\Factory;
 
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\FactoryInterface;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use HtImgModule\Imagine\Resolver\ImagePathStackResolver;
 
 class ImagePathStackResolverFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $resolvers)
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $serviceLocator = $resolvers->getServiceLocator();
-        $options = $serviceLocator->get('HtImg\ModuleOptions');
+        // For v2, we need to pull the parent service locator
+        if (!method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator() ?: $container;
+        }
+        $options = $container->get('HtImg\ModuleOptions');
 
         return new ImagePathStackResolver([
             'script_paths' => $options->getImgSourcePathStack()
         ]);
+    }
+
+    public function createService(ServiceLocatorInterface $resolvers)
+    {
+        return $this($resolvers, ImagePathStackResolver::class);
     }
 }

--- a/src/View/Helper/Factory/ImgUrlFactory.php
+++ b/src/View/Helper/Factory/ImgUrlFactory.php
@@ -1,20 +1,48 @@
 <?php
 namespace HtImgModule\View\Helper\Factory;
 
+use HtImgModule\Imagine\Filter\FilterManager;
+use HtImgModule\Imagine\Loader\LoaderManager;
+use HtImgModule\Service\CacheManager;
+use Interop\Container\ContainerInterface;
+use Interop\Container\Exception\ContainerException;
+use Zend\ServiceManager\Exception\ServiceNotCreatedException;
+use Zend\ServiceManager\Exception\ServiceNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 use Zend\ServiceManager\FactoryInterface;
 use HtImgModule\View\Helper\ImgUrl;
 
 class ImgUrlFactory implements FactoryInterface
 {
-    public function createService(ServiceLocatorInterface $helpers)
+
+    /**
+     * Create an object
+     *
+     * @param  ContainerInterface $container
+     * @param  string             $requestedName
+     * @param  null|array         $options
+     *
+     * @return object
+     * @throws ServiceNotFoundException if unable to resolve the service.
+     * @throws ServiceNotCreatedException if an exception is raised when
+     *     creating a service.
+     * @throws ContainerException if any other error occurs
+     */
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $serviceLocator = $helpers->getServiceLocator();
+        if (! method_exists($container, 'configure')) {
+            $container = $container->getServiceLocator();
+        }
 
         return new ImgUrl(
-            $serviceLocator->get('HtImgModule\Service\CacheManager'),
-            $serviceLocator->get('HtImgModule\Imagine\Filter\FilterManager'),
-            $serviceLocator->get('HtImgModule\Imagine\Loader\LoaderManager')
+            $container->get(CacheManager::class),
+            $container->get(FilterManager::class),
+            $container->get(LoaderManager::class)
         );
+    }
+
+    public function createService(ServiceLocatorInterface $helpers)
+    {
+        return $this($helpers, ImgUrl::class);
     }
 }

--- a/src/View/Helper/Factory/ImgUrlFactory.php
+++ b/src/View/Helper/Factory/ImgUrlFactory.php
@@ -30,7 +30,7 @@ class ImgUrlFactory implements FactoryInterface
      */
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        if (! method_exists($container, 'configure')) {
+        if (!method_exists($container, 'configure')) {
             $container = $container->getServiceLocator();
         }
 

--- a/tests/HtImgModuleTest/Controller/Factory/ImageControllerFactoryTest.php
+++ b/tests/HtImgModuleTest/Controller/Factory/ImageControllerFactoryTest.php
@@ -12,7 +12,7 @@ class ImageControllerFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager = new ServiceManager();
         $serviceManager->setService('HtImgModule\Service\ImageService', $this->getMock('HtImgModule\Service\ImageServiceInterface'));
         $factory = new ImageControllerFactory();
-        $controllers = new ControllerManager;
+        $controllers = new ControllerManager($serviceManager);
         $controllers->setServiceLocator($serviceManager);
         $this->assertInstanceOf('HtImgModule\Controller\ImageController', $factory->createService($controllers));
     }

--- a/tests/HtImgModuleTest/Controller/Factory/ImageControllerFactoryTest.php
+++ b/tests/HtImgModuleTest/Controller/Factory/ImageControllerFactoryTest.php
@@ -13,7 +13,13 @@ class ImageControllerFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager->setService('HtImgModule\Service\ImageService', $this->getMock('HtImgModule\Service\ImageServiceInterface'));
         $factory = new ImageControllerFactory();
         $controllers = new ControllerManager($serviceManager);
-        $controllers->setServiceLocator($serviceManager);
-        $this->assertInstanceOf('HtImgModule\Controller\ImageController', $factory->createService($controllers));
+
+        // Test with ServiceManager v2
+        if (!method_exists($serviceManager, 'configure')) {
+            $controllers->setServiceLocator($serviceManager);
+            $this->assertInstanceOf('HtImgModule\Controller\ImageController', $factory->createService($controllers));
+        } else {
+            $this->assertInstanceOf('HtImgModule\Controller\ImageController', $factory->createService($serviceManager));
+        }
     }
 }

--- a/tests/HtImgModuleTest/Controller/ImageControllerTest.php
+++ b/tests/HtImgModuleTest/Controller/ImageControllerTest.php
@@ -6,6 +6,7 @@ use HtImgModule\Exception;
 use Zend\Mvc\MvcEvent;
 use Phine\Test\Property;
 use Zend\Mvc\Controller\PluginManager;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
 class ImageControllerTest extends \PHPUnit_Framework_TestCase
 {
@@ -17,8 +18,12 @@ class ImageControllerTest extends \PHPUnit_Framework_TestCase
 
         $relativePath = 'relative/path/of/image';
         $filter = 'awesome_filter';
-
-        $pluginManager = new PluginManager();
+        $container = $this->getMock(ServiceLocatorInterface::class);
+        if (!method_exists(PluginManager::class, 'configure')) {
+            $pluginManager = new PluginManager();
+        } else {
+            $pluginManager = new PluginManager($container);
+        }
         $controller->setPluginManager($pluginManager);
         $paramsPlugin = $this->getMock('Zend\Mvc\Controller\Plugin\Params');
         $pluginManager->setService('params', $paramsPlugin);
@@ -50,7 +55,12 @@ class ImageControllerTest extends \PHPUnit_Framework_TestCase
         $relativePath = 'relative/path/of/image';
         $filter = 'awesome_filter';
 
-        $pluginManager = new PluginManager();
+        $container = $this->getMock(ServiceLocatorInterface::class);
+        if (!method_exists(PluginManager::class, 'configure')) {
+            $pluginManager = new PluginManager();
+        } else {
+            $pluginManager = new PluginManager($container);
+        }
         $controller->setPluginManager($pluginManager);
         $paramsPlugin = $this->getMock('Zend\Mvc\Controller\Plugin\Params');
         $pluginManager->setService('params', $paramsPlugin);
@@ -82,7 +92,12 @@ class ImageControllerTest extends \PHPUnit_Framework_TestCase
         $relativePath = 'relative/path/of/image';
         $filter = 'awesome_filter';
 
-        $pluginManager = new PluginManager();
+        $container = $this->getMock(ServiceLocatorInterface::class);
+        if (!method_exists(PluginManager::class, 'configure')) {
+            $pluginManager = new PluginManager();
+        } else {
+            $pluginManager = new PluginManager($container);
+        }
         $controller->setPluginManager($pluginManager);
         $paramsPlugin = $this->getMock('Zend\Mvc\Controller\Plugin\Params');
         $pluginManager->setService('params', $paramsPlugin);
@@ -116,7 +131,11 @@ class ImageControllerTest extends \PHPUnit_Framework_TestCase
     {
         $event = new MvcEvent();
         $controller->setEvent($event);
-        $routeMatch = $this->getMockBuilder('Zend\Mvc\Router\RouteMatch')
+        $mockRouteMatchClass = 'Zend\Mvc\Router\RouteMatch';
+        if (class_exists(\Zend\Router\RouteMatch::class)) {
+            $mockRouteMatchClass = \Zend\Router\RouteMatch::class;
+        }
+        $routeMatch = $this->getMockBuilder($mockRouteMatchClass)
             ->disableOriginalConstructor()
             ->getMock();
         $event->setRouteMatch($routeMatch);
@@ -124,6 +143,7 @@ class ImageControllerTest extends \PHPUnit_Framework_TestCase
         $response->expects($this->once())
             ->method('setStatusCode')
             ->with(404);
+        $event->setResponse($response);
         Property::set($controller, 'response', $response);
     }
 }

--- a/tests/HtImgModuleTest/Factory/FilterManagerFactoryTest.php
+++ b/tests/HtImgModuleTest/Factory/FilterManagerFactoryTest.php
@@ -12,7 +12,12 @@ class FilterManagerFactoryTest extends \PHPUnit_Framework_TestCase
     {
         $serviceManager = new ServiceManager();
         $serviceManager->setService('HtImg\ModuleOptions', new ModuleOptions);
-        $serviceManager->setService('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager', new FilterLoaderPluginManager);
+        if (!method_exists($serviceManager, 'configure')) {
+            $pluginManager = new FilterLoaderPluginManager;
+        } else {
+            $pluginManager = new FilterLoaderPluginManager($serviceManager);
+        }
+        $serviceManager->setService('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager', $pluginManager);
         $factory = new FilterManagerFactory();
         $this->assertInstanceOf('HtImgModule\Imagine\Filter\FilterManager', $factory->createService($serviceManager));
     }

--- a/tests/HtImgModuleTest/Factory/Imagine/Loader/FileSystemLoaderFactoryTest.php
+++ b/tests/HtImgModuleTest/Factory/Imagine/Loader/FileSystemLoaderFactoryTest.php
@@ -12,10 +12,17 @@ class FileSystemLoaderFactoryTest extends \PHPUnit_Framework_TestCase
         $resolver = $this->getMock('HtImgModule\Imagine\Resolver\ResolverInterface');
         $serviceManager->setService('HtImg\RelativePathResolver', $resolver);
         $factory = new FileSystemLoaderFactory();
-        $imageLoaders = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
-        $imageLoaders->expects($this->once())
-            ->method('getServiceLocator')
-            ->will($this->returnValue($serviceManager));
+        $imageLoaders = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $imageLoaders->expects($this->once())
+                ->method('getServiceLocator')
+                ->will($this->returnValue($serviceManager));
+        } else {
+            $imageLoaders = $serviceManager;
+        }
+
         $this->assertInstanceOf('HtImgModule\Imagine\Loader\FileSystemLoader', $factory->createService($imageLoaders));
     }
 }

--- a/tests/HtImgModuleTest/Factory/RelativePathResolverFactoryTest.php
+++ b/tests/HtImgModuleTest/Factory/RelativePathResolverFactoryTest.php
@@ -16,7 +16,9 @@ class RelativePathResolverFactoryTest extends \PHPUnit_Framework_TestCase
         $options = new ModuleOptions;
         $options->setImageResolvers([1000 => 'image_map']);
         $serviceManager->setService('HtImg\ModuleOptions', $options);
-        $resolverManager = $this->getMock('HtImgModule\Imagine\Resolver\ResolverManager');
+        $resolverManager = $this->getMockBuilder('HtImgModule\Imagine\Resolver\ResolverManager')
+            ->disableOriginalConstructor()
+            ->getMock();
         $resolverManager->expects($this->once())
             ->method('get')
             ->will($this->returnValue($this->getMock('Zend\View\Resolver\ResolverInterface')));
@@ -30,8 +32,12 @@ class RelativePathResolverFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager = new ServiceManager();
         $options = new ModuleOptions;
         $serviceManager->setService('HtImg\ModuleOptions', $options);
-        $resolverManager = new ResolverManager;
-        $resolverManager->setServiceLocator($serviceManager);
+        if (!method_exists($serviceManager, 'configure')) {
+            $resolverManager = new ResolverManager;
+            $resolverManager->setServiceLocator($serviceManager);
+        } else {
+            $resolverManager = new ResolverManager($serviceManager);
+        }
         $serviceManager->setService('HtImgModule\Imagine\Resolver\ResolverManager', $resolverManager);
         $factory = new RelativePathResolverFactory();
         $resolver = $factory->createService($serviceManager);

--- a/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/BackgroundFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/BackgroundFactoryTest.php
@@ -11,10 +11,16 @@ class BackgroundFactoryTest extends \PHPUnit_Framework_Testcase
     {
         $serviceManager = new ServiceManager;
         $serviceManager->setService('HtImg\Imagine', new Imagine);
-        $loaders = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
-        $loaders->expects($this->any())
-            ->method('getServiceLocator')
-           ->will($this->returnValue($serviceManager));
+        $loaders = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $loaders->expects($this->any())
+                ->method('getServiceLocator')
+               ->will($this->returnValue($serviceManager));
+        } else {
+            $loaders = $serviceManager;
+        }
         $factory = new BackgroundFactory();
         $loader = $factory->createService($loaders);
         $this->assertInstanceOf('HtImgModule\Imagine\Filter\Loader\Background', $loader);

--- a/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/ChainFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/ChainFactoryTest.php
@@ -9,11 +9,20 @@ class ChainFactoryTest extends \PHPUnit_Framework_Testcase
     public function testFactory()
     {
         $serviceManager = new ServiceManager;
-        $serviceManager->setService('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager', $this->getMock('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager'));
-        $loaders = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
-        $loaders->expects($this->any())
-            ->method('getServiceLocator')
-           ->will($this->returnValue($serviceManager));
+        $serviceManager->setService(
+            'HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager',
+            $this->getMockBuilder('HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager')->disableOriginalConstructor()->getMock()
+        );
+        $loaders = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $loaders->expects($this->any())
+                ->method('getServiceLocator')
+               ->will($this->returnValue($serviceManager));
+        } else {
+            $loaders = $serviceManager;
+        }
         $factory = new ChainFactory();
         $loader = $factory->createService($loaders);
         $this->assertInstanceOf('HtImgModule\Imagine\Filter\Loader\Chain', $loader);

--- a/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/PasteFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/PasteFactoryTest.php
@@ -12,10 +12,16 @@ class PasteFactoryTest extends \PHPUnit_Framework_Testcase
         $serviceManager = new ServiceManager;
         $serviceManager->setService('HtImg\Imagine', new Imagine);
         $serviceManager->setService('HtImg\RelativePathResolver', $this->getMock('Zend\View\Resolver\ResolverInterface'));
-        $loaders = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
-        $loaders->expects($this->any())
-            ->method('getServiceLocator')
-           ->will($this->returnValue($serviceManager));
+        $loaders = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $loaders->expects($this->any())
+                ->method('getServiceLocator')
+               ->will($this->returnValue($serviceManager));
+        } else {
+            $loaders = $serviceManager;
+        }
         $factory = new PasteFactory();
         $loader = $factory->createService($loaders);
         $this->assertInstanceOf('HtImgModule\Imagine\Filter\Loader\Paste', $loader);

--- a/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/WatermarkFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Filter/Loader/Factory/WatermarkFactoryTest.php
@@ -12,10 +12,16 @@ class WatermarkFactoryTest extends \PHPUnit_Framework_Testcase
         $serviceManager = new ServiceManager;
         $serviceManager->setService('HtImg\Imagine', new Imagine);
         $serviceManager->setService('HtImg\RelativePathResolver', $this->getMock('Zend\View\Resolver\ResolverInterface'));
-        $loaders = $this->getMock('Zend\ServiceManager\AbstractPluginManager');
-        $loaders->expects($this->any())
-            ->method('getServiceLocator')
-           ->will($this->returnValue($serviceManager));
+        $loaders = $this->getMockBuilder('Zend\ServiceManager\AbstractPluginManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $loaders->expects($this->any())
+                ->method('getServiceLocator')
+               ->will($this->returnValue($serviceManager));
+        } else {
+            $loaders = $serviceManager;
+        }
         $factory = new WatermarkFactory();
         $loader = $factory->createService($loaders);
         $this->assertInstanceOf('HtImgModule\Imagine\Filter\Loader\Watermark', $loader);

--- a/tests/HtImgModuleTest/Imagine/Filter/Loader/FilterLoaderPluginManagerTest.php
+++ b/tests/HtImgModuleTest/Imagine/Filter/Loader/FilterLoaderPluginManagerTest.php
@@ -2,18 +2,19 @@
 namespace HtImgModuleTest\Imagine\Filter\Loader;
 
 use HtImgModule\Imagine\Filter\Loader\FilterLoaderPluginManager;
+use Zend\ServiceManager\ServiceManager;
 
 class FilterLoaderPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatePlugin()
     {
-        $filterLoaders = new FilterLoaderPluginManager;
+        $filterLoaders = new FilterLoaderPluginManager(new ServiceManager());
         $this->assertEquals(null, $filterLoaders->validatePlugin($this->getMock('HtImgModule\Imagine\Filter\Loader\LoaderInterface')));
     }
 
     public function testGetExceptionWithInvalidPlugin()
     {
-        $filterLoaders = new FilterLoaderPluginManager;
+        $filterLoaders = new FilterLoaderPluginManager(new ServiceManager());
         $this->setExpectedException('HtImgModule\Exception\InvalidArgumentException');
         $filterLoaders->validatePlugin(new \ArrayObject);
     }

--- a/tests/HtImgModuleTest/Imagine/Loader/LoaderPluginManagerTest.php
+++ b/tests/HtImgModuleTest/Imagine/Loader/LoaderPluginManagerTest.php
@@ -2,20 +2,23 @@
 namespace HtImgModuleTest\Imagine\Loader;
 
 use HtImgModule\Imagine\Loader\LoaderPluginManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\ServiceManager;
 
 class LoaderPluginManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testValidatePlugin()
     {
         $loader = $this->getMock('HtImgModule\Imagine\Loader\LoaderInterface');
-        $loaders = new LoaderPluginManager;
+        $loaders = new LoaderPluginManager(new ServiceManager());
         $this->assertEquals(null, $loaders->validatePlugin($loader));
     }
 
     public function testGetExceptionWithInvalidLoader()
     {
-        $loaders = new LoaderPluginManager;
+        $loaders = new LoaderPluginManager(new ServiceManager());
         $this->setExpectedException('HtImgModule\Exception\InvalidArgumentException');
+
         $loaders->validatePlugin(new \ArrayObject);
     }
 }

--- a/tests/HtImgModuleTest/Imagine/Resolver/Factory/ImageMapResolverFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Resolver/Factory/ImageMapResolverFactoryTest.php
@@ -12,10 +12,16 @@ class ImageMapResolverFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager = new ServiceManager;
         $serviceManager->setService('HtImg\ModuleOptions', new ModuleOptions);
         $factory = new ImageMapResolverFactory;
-        $resolvers = $this->getMock('HtImgModule\Imagine\Resolver\ResolverManager');
-        $resolvers->expects($this->once())
-            ->method('getServiceLocator')
-            ->will($this->returnValue($serviceManager));
+        $resolvers = $this->getMockBuilder('HtImgModule\Imagine\Resolver\ResolverManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $resolvers->expects($this->once())
+                ->method('getServiceLocator')
+                ->will($this->returnValue($serviceManager));
+        } else {
+            $resolvers = $serviceManager;
+        }
         $this->assertInstanceOf('HtImgModule\Imagine\Resolver\ImageMapResolver', $factory->createService($resolvers));
     }
 }

--- a/tests/HtImgModuleTest/Imagine/Resolver/Factory/ImagePathStackResolverFactoryTest.php
+++ b/tests/HtImgModuleTest/Imagine/Resolver/Factory/ImagePathStackResolverFactoryTest.php
@@ -12,10 +12,16 @@ class ImagePathStackResolverFactoryTest extends \PHPUnit_Framework_TestCase
         $serviceManager = new ServiceManager;
         $serviceManager->setService('HtImg\ModuleOptions', new ModuleOptions);
         $factory = new ImagePathStackResolverFactory;
-        $resolvers = $this->getMock('HtImgModule\Imagine\Resolver\ResolverManager');
-        $resolvers->expects($this->once())
-            ->method('getServiceLocator')
-            ->will($this->returnValue($serviceManager));
+        $resolvers = $this->getMockBuilder('HtImgModule\Imagine\Resolver\ResolverManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+        if (!method_exists($serviceManager, 'configure')) {
+            $resolvers->expects($this->once())
+                ->method('getServiceLocator')
+                ->will($this->returnValue($serviceManager));
+        } else {
+            $resolvers = $serviceManager;
+        }
         $this->assertInstanceOf('HtImgModule\Imagine\Resolver\ImagePathStackResolver', $factory->createService($resolvers));
     }
 }

--- a/tests/HtImgModuleTest/Imagine/Resolver/ResolverManagerTest.php
+++ b/tests/HtImgModuleTest/Imagine/Resolver/ResolverManagerTest.php
@@ -2,14 +2,23 @@
 namespace HtImgModuleTest\Imagine\Resolver;
 
 use HtImgModule\Imagine\Resolver\ResolverManager;
+use Zend\ServiceManager\Exception\InvalidServiceException;
+use Zend\ServiceManager\ServiceManager;
 
 class ResolverManagerTest extends \PHPUnit_Framework_TestCase
 {
     public function testGetExceptionWithInvalidResolver()
     {
-        $resolverManager = new ResolverManager;
+        $serviceManager = new ServiceManager();
+        if (!method_exists($serviceManager, 'configure')) {
+            $resolverManager = new ResolverManager;
+            $this->setExpectedException('HtImgModule\Exception\InvalidArgumentException');
+        } else {
+            $resolverManager = new ResolverManager($serviceManager);
+            $this->setExpectedException(InvalidServiceException::class);
+        }
         $resolverManager->setInvokableClass('abcd', 'ArrayObject');
-        $this->setExpectedException('HtImgModule\Exception\InvalidArgumentException');
+
         $resolverManager->get('abcd');
     }
 }

--- a/tests/HtImgModuleTest/View/Helper/DisplayImageTest.php
+++ b/tests/HtImgModuleTest/View/Helper/DisplayImageTest.php
@@ -2,6 +2,7 @@
 namespace HtImgModuleTest\View\Helper;
 
 use HtImgModule\View\Helper\DisplayImage;
+use Zend\ServiceManager\ServiceManager;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\HelperPluginManager;
 
@@ -19,7 +20,13 @@ class DisplayImageTest extends \PHPUnit_Framework_TestCase
         $helper = new DisplayImage;
         $helper->setAttributes(['alt' => 'hello']);
         $renderer = new PhpRenderer;
-        $helpers = new HelperPluginManager;
+        $serviceManager = new ServiceManager();
+        if (!method_exists($serviceManager, 'configure')) {
+            $helpers = new HelperPluginManager;
+        } else {
+            $helpers = new HelperPluginManager($serviceManager);
+        }
+
         $renderer->setHelperPluginManager($helpers);
 
         $doctype = $this->getMock('Zend\View\Helper\Doctype');


### PR DESCRIPTION
Hi guys!
I implemented todo to support ZF3 in this pull request. Also was
- set minimum supported PHP version to 5.6 (required by ZF)
- code style (using ::class)
- update composer.json to tagged latest version of dependencies
- Exposed to zend-component-installer as ZF module in composer.json

Please check & review this. If all ok - I suggest create v1.0 release with it (or 0.5.0?).