### PR TITLE
ZF3 compatibility fix: now config is case sensitive

### DIFF
--- a/src/Imagine/Filter/FilterManager.php
+++ b/src/Imagine/Filter/FilterManager.php
@@ -27,8 +27,7 @@ class FilterManager implements FilterManagerInterface
     public function __construct(
         FilterOptionsInterface $filterOptions,
         ServiceLocatorInterface $filterLoaderPluginManager
-    )
-    {
+    ) {
         $this->filterOptions = $filterOptions;
         $this->filterLoaderPluginManager = $filterLoaderPluginManager;
     }

--- a/src/Imagine/Filter/Loader/FilterLoaderPluginManager.php
+++ b/src/Imagine/Filter/Loader/FilterLoaderPluginManager.php
@@ -11,9 +11,14 @@ class FilterLoaderPluginManager extends AbstractPluginManager
     protected $instanceOf = LoaderInterface::class;
 
     protected $aliases  = [
+        'Crop' => Crop::class,
         'crop' => Crop::class,
+        'RelativeResize' => RelativeResize::class,
+        'relativeResize' => RelativeResize::class,
         'relativeresize' => RelativeResize::class,
+        'Resize' => Resize::class,
         'resize' => Resize::class,
+        'Thumbnail' => Thumbnail::class,
         'thumbnail' => Thumbnail::class,
     ];
 

--- a/src/Imagine/Loader/LoaderPluginManager.php
+++ b/src/Imagine/Loader/LoaderPluginManager.php
@@ -11,6 +11,11 @@ class LoaderPluginManager extends AbstractPluginManager
 {
     protected $instanceOf = LoaderInterface::class;
 
+    protected $aliases = [
+        'FileSystem' => 'filesystem',
+        'Simple' => 'simple',
+    ];
+
     protected $factories = [
         'filesystem' => FileSystemLoaderFactory::class,
         'simple'     => SimpleFileSystemLoaderFactory::class,

--- a/src/Imagine/Resolver/ResolverManager.php
+++ b/src/Imagine/Resolver/ResolverManager.php
@@ -15,6 +15,11 @@ class ResolverManager extends AbstractPluginManager
      */
     protected $aliases = [
         'image_path_stack' => 'imagepathstack',
+        'imagePathStack' => 'imagepathstack',
+        'ImagePathStack' => 'imagepathstack',
+        'image_map' => 'imagemap',
+        'imageMap' => 'imagemap',
+        'ImageMap' => 'imagemap',
     ];
 
     protected $factories  = [


### PR DESCRIPTION
In ZF3 Service Manager (PluginManager) config do not normalized anymore: https://zendframework.github.io/zend-servicemanager/migration/#case-sensitivity-and-normalization