### PR TITLE
Inject ServiceLocator to avoid deprecation notice

### DIFF
--- a/src/Factory/Imagine/Loader/LoaderPluginManagerFactory.php
+++ b/src/Factory/Imagine/Loader/LoaderPluginManagerFactory.php
@@ -10,6 +10,8 @@ class LoaderPluginManagerFactory implements FactoryInterface
 {
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
-        return new LoaderPluginManager(new Config($serviceLocator->get('Config')['htimg']['loaders']));
+        $loaderPluginManager = new LoaderPluginManager(new Config($serviceLocator->get('Config')['htimg']['loaders']));
+        $loaderPluginManager->setServiceLocator($serviceLocator);
+        return $loaderPluginManager;
     }
 }


### PR DESCRIPTION
Fixes deprecation notice of ServiceLocatorAwareInterface when using ZF 2.5.3.
Proposed release name: 0.4.2

I propose a new branch called 0.4.x - which i can change this pull request to target.